### PR TITLE
Delete customer list entries helper

### DIFF
--- a/hostflash
+++ b/hostflash
@@ -803,7 +803,7 @@ function __conf_update() {
 	# Add or remove a single host from the .hf*rc config files
 	# ! Considered merging this function with __hosts_update. Opted to keep the two separate. It simplifies input sanitization (to come later).
 
-	# @1 = type: add, rem or remw
+	# @1 = type: add, rem, remw, or remn (remove by line number)
 	# @2 = data to add/remove
 	# @3 = file to add/remove @1 to/from
 
@@ -828,6 +828,13 @@ function __conf_update() {
 		remw)
 			sed -r -i "s/.*?${d}.*?$//g" "${f}" # Remove any line with a match
 			sed -i '/^$/d' "${f}" # Remove empty lines
+		;;
+
+		remn)
+			if [ $d != '' ]; then
+				sed -i "${d}d" "${f}" # Remove the line number $d from the file
+				sed -i '/^$/d' "${f}" # Remove empty lines
+			fi
 		;;
 	esac
 	
@@ -887,6 +894,37 @@ function __conf_delete() {
 		esac
 	done
 
+}
+
+function __remove_custom_list_entry_menu() {
+	filename=$1
+	description=$2
+
+	printf "Custom $description is located at $filename\n\n"
+	__display_file $filename
+	printf "\nType the line number to remove then press Enter. Press 0 to exit:\n\n"
+	read a
+
+	case $a in
+		0)
+			__repaint '__menu_custom_list_management' # Effectively 'Return here'
+		;;
+
+		*)
+			__conf_update 'remn' "$a" "$filename"
+			__repaint '__menu_custom_list_management' # Effectively 'Return here'
+		;;
+	esac
+}
+
+function __display_file() {
+	filename=$1
+
+	n=1
+	while read LINE; do
+		printf "$n) $LINE\n"
+		let n=n+1
+	done < $filename
 }
 
 function __status() {
@@ -1809,58 +1847,19 @@ function __menu_custom_list_management() {
 
 			4) # Remove from custom whitelist
 
-				printf "Custom whitelist is located at ${file[confwl]}\n\n"
-				printf "Type in a host to add then press Enter. Press 0 to exit:\n\n"
-				read a
-
-				case $a in
-					0)
-						__repaint '__menu_custom_list_management' # Effectively 'Return here'
-					;;
-					
-					*)
-						__conf_update 'rem' "$a" "${file[confwl]}"
-						__repaint '__menu_custom_list_management' # Effectively 'Return here'
-					;;
-				esac
+				__remove_custom_list_entry_menu ${file[confwl]} "whitelist"
 
 			;;
 
 			5) # Remove from custom wild whitelist
 
-				printf "Custom wild whitelist is located at ${file[confwlw]}\n\n"
-				printf "Type in a host to add then press Enter. Press 0 to exit:\n\n"
-				read a
-
-				case $a in
-					0)
-						__repaint '__menu_custom_list_management' # Effectively 'Return here'
-					;;
-					
-					*)
-						__conf_update 'rem' "$a" "${file[confwlw]}"
-						__repaint '__menu_custom_list_management' # Effectively 'Return here'
-					;;
-				esac
+				__remove_custom_list_entry_menu ${file[confwlw]} "wild whitelist"
 
 			;;
 
 			6) # Remove from custom blacklist
 
-				printf "Custom blacklist is located at ${file[confbl]}\n\n"
-				printf "Type in a host to add then press Enter. Press 0 to exit:\n\n"
-				read a
-
-				case $a in
-					0)
-						__repaint '__menu_custom_list_management' # Effectively 'Return here'
-					;;
-					
-					*)
-						__conf_update 'rem' "$a" "${file[confbl]}"
-						__repaint '__menu_custom_list_management' # Effectively 'Return here'
-					;;
-				esac
+				__remove_custom_list_entry_menu ${file[confbl]} "blacklist"
 
 			;;
 

--- a/hostflash
+++ b/hostflash
@@ -1,5 +1,4 @@
 #!/bin/bash
-clear
 # set -euo pipefail
 # set -x
 IFS=$'\n\t'
@@ -187,6 +186,14 @@ file[hosts]=''
 
 # Custom Hosts File location
 # file[hosts]='/enter/path/to/file/called/hosts' # Add the path to your system's hosts file then uncomment (remove the #) and save to activate.
+
+function __clear() {
+	if [ $debug == '0' ]; then
+		clear
+	fi
+}
+
+__clear
 
 if test ! "${file[hosts]}"; then
 	if test -f "/system/etc/hosts"; then
@@ -638,7 +645,7 @@ function __repaint() {
 	#
 	# We use $in instead of $@
 	
-	clear
+	__clear
 	
 	in=( $@ )
 	
@@ -1411,7 +1418,7 @@ function __menu_main() {
 
 		8) # Update hosts file with new custom rules
 
-			clear
+			__clear
 
 			printf "This next part could take some time.\nLook in ${dir[tmp]} to view activity in realtime.\n\nProcessing...\n"
 
@@ -1446,7 +1453,7 @@ function __menu_main() {
 		;;
 		
 		9)
-			clear
+			__clear
 			__cleandns
 			printf "\nPress any key"
 			read a
@@ -1637,7 +1644,7 @@ function __menu_remote_list_management() {
 
 			[Aa])
 
-				clear
+				__clear
 
 				printf "\nEnter details for new resource list ${n}.\n\n"
 				

--- a/hostflash
+++ b/hostflash
@@ -1265,7 +1265,7 @@ function __menu_main() {
 
 			unset menu
 			menu[1]='List Management (enable or disable repositories)'
-			menu[2]='Custom List Management (add or remove rules)\n'
+			menu[2]='Custom List Management (add or remove whitelist/blacklist rules)\n'
 
 			menu[3]="[${conf[ip]}] - Change redirect IP address\n"
 


### PR DESCRIPTION
TL:DR; remove list entries using line numbers instead of some type of string matching.

I was having issues figuring out how to remove entries with the current remove logic.  Now that I've dug into the code I get how it works, however, it seems something easy to forget.  To make removing entries a no-brainer I added logic to delete entries by line number.  This make working with larger lists a pain, but I figure that if that is the case you're probably editing the lists directly with your favorite editor.

I went back and forth on adding new menu entries, however, I felt that extra entries would confuse the UI.  Thus I replaced the current remove functionality.  Let me know if you feel that the old functionality is still desired and I can add those back in with new entries for this new way.